### PR TITLE
Fix projected value

### DIFF
--- a/src/scripts/chartist-goal-line.js
+++ b/src/scripts/chartist-goal-line.js
@@ -1,3 +1,4 @@
+
 /**
  * Chartist.js plugin to display a "target" or "goal" line across the chart.
  * Only tested with bar charts. Works for horizontal and vertical bars.
@@ -10,10 +11,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
@@ -44,7 +45,7 @@
       chart.on('created', function(context) {
         var projectTarget = {
           y: function (chartRect, bounds, value) {
-            var targetLineY = chartRect.y1 - (chartRect.height() / bounds.max * value);
+            var targetLineY = context.chartRect.height() - context.axisY.projectValue(value) + context.chartRect.y2;
 
             return {
               x1: chartRect.x1,
@@ -54,7 +55,7 @@
             }
           },
           x: function (chartRect, bounds, value) {
-            var targetLineX = chartRect.x1 + (chartRect.width() / bounds.max * value);
+            var targetLineX = context.chartRect.width() - context.axisX.projectValue(value) + context.chartRect.x2;
 
             return {
               x1: targetLineX,


### PR DESCRIPTION
Previous method would put the goal line at the top of the series with the latest Chartist. This method is from Chartist owner's threshold plugin.
